### PR TITLE
ngPreserveWhitespaces

### DIFF
--- a/src/code-block.js
+++ b/src/code-block.js
@@ -28,6 +28,7 @@ const preload = (content, resourcePath) => {
     const rawContent = $elem.html().toString();
     const content = convertToHTMLEntities(rawContent);
     $elem.html(content);
+    $elem.attr('ngPreserveWhitespaces', true);
   });
 
   return $.html().toString();

--- a/src/code-block.spec.js
+++ b/src/code-block.spec.js
@@ -19,6 +19,15 @@ describe('Code Block Plugin', () => {
     expect(result.toString()).toEqual(content.toString());
   });
 
+  it('should add the ngPreserveWhitespaces attribute to the <sky-code-block> tags', () => {
+    const content = new Buffer(`
+      <sky-code-block>
+      </sky-code-block>`);
+    const path = 'foo.html';
+    const result = plugin.preload(content, path);
+    expect(result.toString()).toContain('ngPreserveWhitespaces="true"');
+  });
+
   it('should convert the inner HTML of all <sky-code-block> to HTML entities.', () => {
     const content = new Buffer(`
       <sky-code-block>


### PR DESCRIPTION
Angular 6 removes all extra white spaces from templates.  This has caused the `code-block` to no longer render line breaks properly.  Because the `code-block` uses `ng-content`, the directive needs to live on the `<sky-code-block>` tag.  This update to the plugin acts as a courtesy to our users, adding the attribute for them.